### PR TITLE
Modify tracker to continue until next keyframe while waiting for mapper.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ output*/
 .vscode/
 
 temp/
+
+*.out
+
+configs/

--- a/src/mapper.py
+++ b/src/mapper.py
@@ -150,6 +150,9 @@ class Mapper(object):
         self.frame_idxs = []  # the indices of keyframes in the original frame sequence
         self.video_idxs = []  # keyframe numbering (I sometimes call it kf_idx)
 
+        # Send Initial continue
+        self.pipe.send("continue")
+
         while True:
             if self.config['gui']:
                 if self.q_vis2main.empty():
@@ -167,6 +170,7 @@ class Mapper(object):
             frame_info = self.pipe.recv()
             frame_idx, video_idx = frame_info["timestamp"], frame_info["video_idx"]
             is_init, is_finished = frame_info["just_initialized"], frame_info["end"]
+            self.printer.print(f"Received frame {frame_idx}", FontColor.MAPPER)
 
             if is_finished:
                 self.printer.print("Done with Mapping and Tracking", FontColor.MAPPER)

--- a/src/utils/Printer.py
+++ b/src/utils/Printer.py
@@ -82,6 +82,7 @@ class Printer(TrivialPrinter):
                     pbar.refresh()
                 else:
                     pbar.write(message)
+                    print(message)
         while True:
             message = self.msg_queue.get()
             if message == "DONE":


### PR DESCRIPTION
Improves parallelisation of `Tracker` and `Mapper` modules. 

Instead of `Tracker` waiting for `Mapper` to finish before continuing, `Tracker` will now continue until the next keyframe is ready to be sent, and wait for `Mapper` to finish processing the previous keyframe before sending.